### PR TITLE
update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,25 @@
-## Reporting issues
+# Security Policy
 
-To report a security issue, please report using [GitHub's private security vulnerability report](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
-or email security@chainguard.dev.
+## Reporting a Vulnerability
+
+Thank you for taking the time to disclose a potential security issue.
+
+Please report using [GitHub's private security vulnerability report](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) or via email to [security@chainguard.dev](mailto:security@chainguard.dev). 
+
+To assist our triage, please include:
+- A clear description of the issue and its potential impact.
+- Steps to reproduce or proof-of-concept if available.
+- Affected versions or commit hashes.
+- Any known mitigations or fixes.
+- How you would like to be credited if attribution is desired (e.g., name, known handle).
+
+## Disclosure Policy
+
+We are grateful when vulnerabilities are reported to us.
+
+As a reporter, you can expect:
+- A prompt acknowledgment of your report (within 72 hours).
+- A transparent dialog and timely fix for valid issues.
+- Credit for disclosure, if desired.
+
+Please see the full [Chainguard Vulnerability Disclosure Policy](https://www.chainguard.dev/legal/inbound-vulnerability-disclosure-policy) to learn more.


### PR DESCRIPTION
update based on https://github.com/chainguard-dev/.github/pull/86

this differs from https://github.com/chainguard-dev/.github/pull/86 in that it is an update (instead of init) and the `GitHub's private security vulnerability report` text is included