### PR TITLE
add permissions to read repos for gh audit

### DIFF
--- a/.github/chainguard/audit-gh-automation.sts.yaml
+++ b/.github/chainguard/audit-gh-automation.sts.yaml
@@ -7,6 +7,7 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/audit-gh-automation.yaml@refs/heads/main
 
 permissions:
+  administration: read # read repository
   members: read # to read GitHub members
   metadata: read # to read metadata about the org
 


### PR DESCRIPTION
follow up of https://github.com/chainguard-dev/infra/pull/758